### PR TITLE
Payment types and user profile that is returned from the database now corresponds with the user that is currently logged in

### DIFF
--- a/bangazon_api/views/order_view.py
+++ b/bangazon_api/views/order_view.py
@@ -62,9 +62,10 @@ class OrderView(ViewSet):
         try:
             order = Order.objects.get(pk=pk, user=request.auth.user)
             payment_type = PaymentType.objects.get(
-                pk=request.data['paymentTypeId'], customer=request.auth.user_id)
+                pk=request.data['paymentTypeId'], customer=request.auth.user)
             order.payment_type = payment_type
             order.completed_on = datetime.now()
+            order.save()
             return Response({'message': "Order Completed"})
         except (Order.DoesNotExist, PaymentType.DoesNotExist) as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/bangazon_api/views/order_view.py
+++ b/bangazon_api/views/order_view.py
@@ -62,7 +62,7 @@ class OrderView(ViewSet):
         try:
             order = Order.objects.get(pk=pk, user=request.auth.user)
             payment_type = PaymentType.objects.get(
-                pk=request.data['paymentTypeId'], customer=request.auth.user)
+                pk=request.data['paymentTypeId'], customer=request.auth.user_id)
             order.payment_type = payment_type
             order.completed_on = datetime.now()
             return Response({'message': "Order Completed"})

--- a/bangazon_api/views/payment_type_view.py
+++ b/bangazon_api/views/payment_type_view.py
@@ -18,7 +18,7 @@ class PaymentTypeView(ViewSet):
     })
     def list(self, request):
         """Get a list of payment types for the current user"""
-        payment_types = PaymentType.objects.all()
+        payment_types = PaymentType.objects.filter(customer=request.auth.user)
         serializer = PaymentTypeSerializer(payment_types, many=True)
         return Response(serializer.data)
 
@@ -40,8 +40,8 @@ class PaymentTypeView(ViewSet):
         try:
             payment_type = PaymentType.objects.create(
                 customer=request.auth.user,
-                merchant_name=request.data['acctNumber'],
-                acct_number=request.data['merchant']
+                merchant_name=request.data['merchant'],
+                acct_number=request.data['acctNumber']
             )
             serializer = PaymentTypeSerializer(payment_type)
             return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/bangazon_api/views/profile_view.py
+++ b/bangazon_api/views/profile_view.py
@@ -28,7 +28,7 @@ class ProfileView(ViewSet):
     def my_profile(self, request):
         """Get the current user's profile"""
         try:
-            serializer = UserSerializer(User.objects.first())
+            serializer = UserSerializer(User.objects.get(pk=request.auth.user_id))
             return Response(serializer.data)
         except User.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
- Server was using the `first` ORM method instead of `get` on the User object to get the correct user profile. 
- Payment type list method was using `all` instead of `filter` ORM method to get the correct payment types. We only want to display the payment types created by the current user, so we use `filter` on the PaymentType objects and check if `customer=request.auth-user`