### PR TITLE
can now successfully query products while defining a minimum of produ…

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
   good-names=i,j,ex,pk
 
 [MESSAGES CONTROL]
-  disable=broad-except,imported-auth-user,missing-class-docstring,no-self-use,abstract-method
+  disable=broad-except,imported-auth-user,missing-class-docstring,no-self-use,abstract-method,line-too-long
 
 [MASTER]
   disable=C0114,

--- a/bangazon_api/models/product.py
+++ b/bangazon_api/models/product.py
@@ -26,13 +26,15 @@ class Product(models.Model):
         Returns:
             number -- The average rating for the product
         """
-        # TODO: Fix Divide by zero error
-
         total_rating = 0
-        for rating in self.ratings.all():
-            total_rating += rating.score
+        num_of_ratings = self.ratings.count()
+        avg = 0
 
-        avg = total_rating / self.ratings.count()
+        if num_of_ratings != 0:
+            for rating in self.ratings.all():
+                total_rating += rating.score
+
+            avg = total_rating / num_of_ratings
         return avg
 
     @property

--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -169,10 +169,12 @@ class ProductView(ViewSet):
         name = request.query_params.get('name', None)
 
         if number_sold:
+            number_sold = int(number_sold)
             products = products.annotate(
                 order_count=Count('orders')
-            ).filter(order_count__lt=number_sold)
-
+            ).filter(order_count__gte=number_sold)
+            print(len(products))
+            
         if order is not None:
             order_filter = f'-{order}' if direction == 'desc' else order
             products = products.order_by(order_filter)
@@ -252,7 +254,8 @@ class ProductView(ViewSet):
             product = Product.objects.get(pk=pk)
             order = Order.objects.get(
                 user=request.auth.user, completed_on=None)
-            order_product = OrderProduct.objects.get(product=product, order=order)
+            order_product = OrderProduct.objects.get(
+                product=product, order=order)
             order_product.delete()
             return Response(None, status=status.HTTP_204_NO_CONTENT)
         except OrderProduct.DoesNotExist as ex:


### PR DESCRIPTION
…cts sold

### Issue ticket(s): #3 #9 

### New file(s): n/a

### Modified File(s): `models/product.py` `views/product_view.py`

### Modifications:
- Added an `if` block to the `average_rating` property decorator to check and see if the number of ratings is not zero. If it IS zero, then we dont even run the equation to calculate average, we just return 0
- Refactored the `filter` method used inside the `if` block that checks if `number_sold` exists. The code was originally written using `lt` (less than) on `order_count` instead of `gte`(greater than or equal to).

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-minProductsSold`
3. Query `http://localhost:8000/api/products?number_sold=20` in Postman, you should get back nothing because nothing has been sold more than twenty times. You can try this with a number smaller than 20 to check if something eventually gets returned
