### PR TITLE
can now successfully query products while specifying a minimum price

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -167,6 +167,7 @@ class ProductView(ViewSet):
         order = request.query_params.get('order_by', None)
         direction = request.query_params.get('direction', None)
         name = request.query_params.get('name', None)
+        min_price = request.query_params.get('min_price', None)
 
         if number_sold:
             number_sold = int(number_sold)
@@ -174,7 +175,7 @@ class ProductView(ViewSet):
                 order_count=Count('orders')
             ).filter(order_count__gte=number_sold)
             print(len(products))
-            
+
         if order is not None:
             order_filter = f'-{order}' if direction == 'desc' else order
             products = products.order_by(order_filter)
@@ -184,6 +185,9 @@ class ProductView(ViewSet):
 
         if name is not None:
             products = products.filter(name__icontains=name)
+
+        if min_price is not None:
+            products = products.filter(price__lte=min_price)
 
         serializer = ProductSerializer(products, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
### Issue ticket(s): #7 

### New file(s): N/A

### Modified File(s): `views/product_view.py`

### Modifications:
- added a `min_price` query param within the `list` method ProductView class

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-minPrice`
3. Execute a get request @ `http://localhost:8000/api/products?min_price=150` in Postman. Only the products that are less than or equal to 150 dollars should be retrieved
