### PR TITLE
can now successfully query products that is filtered by a location se…

### DIFF
--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -168,6 +168,7 @@ class ProductView(ViewSet):
         direction = request.query_params.get('direction', None)
         name = request.query_params.get('name', None)
         min_price = request.query_params.get('min_price', None)
+        location = request.query_params.get('location', None)
 
         if number_sold:
             number_sold = int(number_sold)
@@ -188,6 +189,9 @@ class ProductView(ViewSet):
 
         if min_price is not None:
             products = products.filter(price__lte=min_price)
+
+        if location is not None:
+            products = products.filter(location__icontains=location)
 
         serializer = ProductSerializer(products, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
…arch

### Issue ticket(s): #10 

### New file(s): N/A

### Modified File(s): `views/product_view.py`

### Modifications:
- add a `location` query param that, if isn't None, will filter the products by the location search content

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-productsByLocation`
3. Using Postman, execute a GET request on the `products` resource @ `http://localhost:8000/api/products?location=utah`. Only the products that are located in utah should be retrieved. You can repeat this step as many times as necessary by replacing the search criteria in the URL (i.e. utah). 
