### PR TITLE
wrote test for adding a product to an order

### DIFF
--- a/bangazon_api/serializers/user_serializer.py
+++ b/bangazon_api/serializers/user_serializer.py
@@ -6,7 +6,7 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('username', 'first_name', 'last_name', 'orders',
-                  'favorites', 'store', 'recommended_by')
+                  'favorites', 'store', 'recommended_by', 'recommendations')
         depth = 1
 
 


### PR DESCRIPTION
### Issue ticket(s): #14 #23 

### New file(s): N/A

### Modified File(s): `user_serializer.py` `test_product.py`

### Modifications:
- Added a `recommendations` field to the `userSerializer` class
- Wrote `test_cannot_add_product_to_closed_order` method to test if a product can be successfully added to an order that has not been completed yet

### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-testClosedOrder`
3. run `python manage.py test tests -v 1` command in the terminal, you should have 8 tests come back with no failures or errors
4. Next, within Postman, recommend a product to another user by executing a post request @ `http://localhost:8000/api/products/2/recommend`. Your request body should include an object as a JSON string with a "username" property. The value of "username" should be the username of the user you want to recommend the product to. 
5. Finally, change your Authorization header in Postman to the token of the user you just recommended a product to. (This simulates you logging into the client as that user)
6. Perform a get request @ `http://localhost:8000/api/profile/my-profile`, you should have a `recommendations` property come back in your response that has the data about the product that was recommended to this user
