### PR TITLE
implemented tests for deleting payment type, deleting product, product can be rated and average_rating is correct

### DIFF
--- a/bangazon_api/views/payment_type_view.py
+++ b/bangazon_api/views/payment_type_view.py
@@ -59,7 +59,7 @@ class PaymentTypeView(ViewSet):
             )
         }
     )
-    def delete(self, request, pk):
+    def destroy(self, request, pk):
         """Delete a payment type"""
         try:
             payment_type = PaymentType.objects.get(pk=pk)

--- a/tests/test_payment_type.py
+++ b/tests/test_payment_type.py
@@ -5,6 +5,8 @@ from rest_framework.authtoken.models import Token
 from django.core.management import call_command
 from django.contrib.auth.models import User
 
+from bangazon_api.models.payment_type import PaymentType
+
 
 class PaymentTests(APITestCase):
     def setUp(self):
@@ -15,11 +17,12 @@ class PaymentTests(APITestCase):
         self.user1 = User.objects.filter(store=None).first()
         self.token = Token.objects.get(user=self.user1)
 
+        self.payment_type1 = PaymentType.objects.create(customer=self.user1)
+
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.token.key}')
 
         self.faker = Faker()
-
 
     def test_create_payment_type(self):
         """
@@ -33,9 +36,13 @@ class PaymentTests(APITestCase):
 
         response = self.client.post('/api/payment-types', data, format='json')
 
-
-
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertIsNotNone(response.data['id'])
         self.assertEqual(response.data["merchant_name"], data['merchant'])
-        self.assertEqual(response.data["obscured_num"][-4:], data['acctNumber'][-4:])
+        self.assertEqual(response.data["obscured_num"]
+                         [-4:], data['acctNumber'][-4:])
+
+    def test_delete_payment_type(self):
+        response = self.client.delete(
+            f'/api/payment-types/{self.payment_type1.id}')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -88,3 +88,34 @@ class ProductTests(APITestCase):
     def test_delete_product(self):
         response = self.client.delete(f'/api/products/{self.product.id}')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_add_rating_to_product(self):
+        product_unrated = self.product
+        url = f'/api/products/{product_unrated.id}/rate-product'
+        data = {
+            "score": 7,
+            "review": "This is a review, my guy"
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        product_rated = self.client.get(f'/api/products/{product_unrated.id}')
+
+        self.assertEqual(len(product_rated.data['ratings']), 2)
+
+        def average_rating():
+            total_rating = 0
+            num_of_ratings = len(product_rated.data['ratings'])
+            avg = 0
+
+            if num_of_ratings != 0:
+                for rating in product_rated.data['ratings']:
+                    total_rating += rating['score']
+
+                avg = total_rating / num_of_ratings
+            return avg
+
+        avg = average_rating()
+
+        self.assertEqual(product_rated.data['average_rating'], avg)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -81,6 +81,10 @@ class ProductTests(APITestCase):
 
     def test_cannot_add_product_to_closed_order(self):
         """Ensures that a user cannot add a new product to an order that is already closed"""
-        url = f'/api/products/{self.product.id}/add_to_order'
-        response = self.client.post(url)
+        response = self.client.post(
+            f'/api/products/{self.product.id}/add_to_order')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_delete_product(self):
+        response = self.client.delete(f'/api/products/{self.product.id}')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### Issue ticket(s): #15 #16 #17 

### New file(s): N/A

### Modified File(s): `payment_type_view.py` `test_payment_type.py` `test_product.py`

### Modifications:
- Refactored the name of the function that deletes a payment_type object from `delete` to `destroy`
- Added a `test_delete_payment_type` method to the `PaymentTests` class
- Added `test_delete_product` and `test_add_rating_to_product` methods to the `ProductTests` class
### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to `al-finalTests`
3. Run the `python3 manage.py test tests -v 1` command in the terminal while in the projects root directory. 11 tests should come back without any errors or failures
