### PR TITLE
Generated reports for complete and incomplete orders

### DIFF
--- a/-- db.sql
+++ b/-- db.sql
@@ -29,3 +29,14 @@ JOIN bangazon_api_category as c
 ON p.category_id = c.id
 WHERE p.price <= 1000
 ORDER BY product_price
+
+
+SELECT
+o.id as order_id,
+u.first_name || " " || u.last_name as customer,
+o.total,
+o.payment_type.merchant_name as payment_type
+FROM
+bangazon_api_order as o
+JOIN auth_user as u 
+ON o.customer_id = u.id

--- a/-- db.sql
+++ b/-- db.sql
@@ -26,17 +26,46 @@ c.name as category
 FROM
 bangazon_api_product as p
 JOIN bangazon_api_category as c
-ON p.category_id = c.id
+ON p.category_id- = c.id
 WHERE p.price <= 1000
 ORDER BY product_price
 
 
+CREATE VIEW COMPLETED_ORDERS AS
 SELECT
 o.id as order_id,
 u.first_name || " " || u.last_name as customer,
-o.total,
-o.payment_type.merchant_name as payment_type
+SUM(p.price) as order_total,
+pt.merchant_name as payment_type
 FROM
 bangazon_api_order as o
-JOIN auth_user as u 
-ON o.customer_id = u.id
+JOIN 
+auth_user as u,
+bangazon_api_orderproduct as op,
+bangazon_api_product as p,
+bangazon_api_paymenttype as pt
+ON o.user_id = u.id
+AND o.id = op.order_id
+AND op.product_id = p.id
+AND o.payment_type_id = pt.id
+WHERE o.payment_type_id IS NOT NULL
+GROUP BY o.id
+
+CREATE VIEW INCOMPLETE_ORDERS AS
+SELECT
+o.id as order_id,
+u.first_name || " " || u.last_name as customer,
+SUM(p.price) as order_total,
+o.created_on
+FROM
+bangazon_api_order as o
+JOIN 
+auth_user as u,
+bangazon_api_orderproduct as op,
+bangazon_api_product as p
+ON o.user_id = u.id
+AND o.id = op.order_id
+AND op.product_id = p.id
+WHERE o.completed_on ISNULL
+GROUP BY o.id
+

--- a/bangazon_reports/templates/orders/order_list_completed.html
+++ b/bangazon_reports/templates/orders/order_list_completed.html
@@ -1,0 +1,27 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Completed Orders</h1>
+
+    {% for order in orders_completed %}
+        <h2>Order: {{ order.id }}</h2>
+        <ul>
+          <li>
+              Customer: {{ order.customer }}
+          </li>
+          <li>
+            Total: {{ order.order_total }}
+          </li>
+          <li>
+            Payment Type: {{ order.payment_type }}
+          </li>
+            ---------------------------
+        </ul>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazon_reports/templates/orders/order_list_not_completed.html
+++ b/bangazon_reports/templates/orders/order_list_not_completed.html
@@ -1,0 +1,27 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Bangazon Reports</title>
+  </head>
+  <body>
+    <h1>Incomplete Orders</h1>
+
+    {% for order in orders_incomplete %}
+        <h2>Order: {{ order.id }}</h2>
+        <ul>
+          <li>
+              Customer: {{ order.customer }}
+          </li>
+          <li>
+            Total: {{ order.order_total }}
+          </li>
+          <li>
+            Created on: {{ order.created_on }}
+          </li>
+            ---------------------------
+        </ul>
+    {% endfor %}
+  </body>
+</html>

--- a/bangazon_reports/urls.py
+++ b/bangazon_reports/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
-from .views import ProductListMin1000, ProductListMax1000
+
+from .views import (OrderListCompleted, OrderListIncomplete,
+                    ProductListMax1000, ProductListMin1000)
 
 urlpatterns = [
     path('products/min1000', ProductListMin1000.as_view()),
     path('products/max1000', ProductListMax1000.as_view()),
+    path('orders/completed', OrderListCompleted.as_view()),
+    path('orders/incomplete', OrderListIncomplete.as_view()),
 ]

--- a/bangazon_reports/views/__init__.py
+++ b/bangazon_reports/views/__init__.py
@@ -1,2 +1,4 @@
 from .products.products_min_1000 import ProductListMin1000
 from .products.products_max_1000 import ProductListMax1000
+from .orders.orders_completed import OrderListCompleted
+from .orders.orders_not_completed import OrderListIncomplete

--- a/bangazon_reports/views/orders/orders_completed.py
+++ b/bangazon_reports/views/orders/orders_completed.py
@@ -5,6 +5,12 @@ from django.views import View
 
 from bangazon_reports.views.helpers import dict_fetch_all
 
+# Marketing needs a report showing all orders that have been paid for.
+
+# Order Id
+# Customer name
+# Total paid for the order
+# Payment type
 
 class OrderListCompleted(View):
     def get(self, request):
@@ -14,54 +20,30 @@ class OrderListCompleted(View):
                 SELECT
                 *
                 FROM
-                
+                COMPLETED_ORDERS
             """)
             # Pass the db_cursor to the dict_fetch_all function to turn the fetch_all() response into a dictionary
             dataset = dict_fetch_all(db_cursor)
-
-            # Take the flat data from the dataset, and build the
-            # following data structure for each gamer.
-            # This will be the structure of the games_by_user list:
-            #
-            # [
-            #   {
-            #     "id": 1,
-            #     "full_name": "Admina Straytor",
-            #     "games": [
-            #       {
-            #         "id": 1,
-            #         "title": "Foo",
-            #         "maker": "Bar Games",
-            #         "skill_level": 3,
-            #         "number_of_players": 4,
-            #         "game_type_id": 2
-            #       },
-            #       {
-            #         "id": 2,
-            #         "title": "Foo 2",
-            #         "maker": "Bar Games 2",
-            #         "skill_level": 3,
-            #         "number_of_players": 4,
-            #         "game_type_id": 2
-            #       }
-            #     ]
-            #   },
-            # ]
 
             order_list = []
 
             for row in dataset:
                 
-                order = {}
+                order = {
+                    "id": row['order_id'],
+                    "customer": row['customer'],
+                    "order_total": row['order_total'],
+                    "payment_type": row['payment_type']
+                }
                 
                 order_list.append(order)
 
         # The template string must match the file name of the html template
-        template = 'orders/orders_completed.html'
+        template = 'orders/order_list_completed.html'
 
         # The context will be a dictionary that the template can access to show data
         context = {
-            "order_list": order_list
+            "orders_completed": order_list
         }
 
         return render(request, template, context)

--- a/bangazon_reports/views/orders/orders_completed.py
+++ b/bangazon_reports/views/orders/orders_completed.py
@@ -1,0 +1,67 @@
+"""Module for generating games by user report"""
+from django.shortcuts import render
+from django.db import connection
+from django.views import View
+
+from bangazon_reports.views.helpers import dict_fetch_all
+
+
+class OrderListCompleted(View):
+    def get(self, request):
+        with connection.cursor() as db_cursor:
+
+            db_cursor.execute("""
+                SELECT
+                *
+                FROM
+                
+            """)
+            # Pass the db_cursor to the dict_fetch_all function to turn the fetch_all() response into a dictionary
+            dataset = dict_fetch_all(db_cursor)
+
+            # Take the flat data from the dataset, and build the
+            # following data structure for each gamer.
+            # This will be the structure of the games_by_user list:
+            #
+            # [
+            #   {
+            #     "id": 1,
+            #     "full_name": "Admina Straytor",
+            #     "games": [
+            #       {
+            #         "id": 1,
+            #         "title": "Foo",
+            #         "maker": "Bar Games",
+            #         "skill_level": 3,
+            #         "number_of_players": 4,
+            #         "game_type_id": 2
+            #       },
+            #       {
+            #         "id": 2,
+            #         "title": "Foo 2",
+            #         "maker": "Bar Games 2",
+            #         "skill_level": 3,
+            #         "number_of_players": 4,
+            #         "game_type_id": 2
+            #       }
+            #     ]
+            #   },
+            # ]
+
+            order_list = []
+
+            for row in dataset:
+                
+                order = {}
+                
+                order_list.append(order)
+
+        # The template string must match the file name of the html template
+        template = 'orders/orders_completed.html'
+
+        # The context will be a dictionary that the template can access to show data
+        context = {
+            "order_list": order_list
+        }
+
+        return render(request, template, context)

--- a/bangazon_reports/views/orders/orders_not_completed.py
+++ b/bangazon_reports/views/orders/orders_not_completed.py
@@ -1,0 +1,49 @@
+"""Module for generating games by user report"""
+from django.shortcuts import render
+from django.db import connection
+from django.views import View
+
+from bangazon_reports.views.helpers import dict_fetch_all
+
+# Marketing needs a report showing all orders that have not been paid for yet. Order by the created_on date, oldest first
+
+# Order Id
+# Customer name
+# Total cost of all items on the order
+# created_on
+
+class OrderListIncomplete(View):
+    def get(self, request):
+        with connection.cursor() as db_cursor:
+
+            db_cursor.execute("""
+                SELECT
+                *
+                FROM
+                INCOMPLETE_ORDERS
+            """)
+            # Pass the db_cursor to the dict_fetch_all function to turn the fetch_all() response into a dictionary
+            dataset = dict_fetch_all(db_cursor)
+
+            order_list = []
+
+            for row in dataset:
+                
+                order = {
+                    "id": row['order_id'],
+                    "customer": row['customer'],
+                    "order_total": row['order_total'],
+                    "created_on": row['created_on'],
+                }
+                
+                order_list.append(order)
+
+        # The template string must match the file name of the html template
+        template = 'orders/order_list_not_completed.html'
+
+        # The context will be a dictionary that the template can access to show data
+        context = {
+            "orders_incomplete": order_list
+        }
+
+        return render(request, template, context)


### PR DESCRIPTION
### Issue ticket(s): #20 #21 

### New file(s): `order_list_completed.html` `order_list_not_completed.html` `orders_completed.py` `orders_not_completed.py`

### Modified File(s): `-- db.sql` `urls.py` `__init__.py`

### Modifications:
- Created two new views in the `-- db.sql`
- Created two new html templates. One for completed orders and another for incomplete orders
- Created report views for both complete and incomplete orders
### Steps to test:
1. While in the terminal, use git fetch --all in the root directory of this repo
2. Checkout out to al-orderReports
3. Run the server.
4. Visit the following urls to confirm reports are being generated with the correct data
- `http://localhost:8000/reports/orders/completed`
- `http://localhost:8000/reports/orders/incomplete`
